### PR TITLE
Adds maximum frequency (in the form of a debounce filter) to the dynamic color updater

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -42,31 +42,71 @@ browser.storage.local.get((pref) => {
 	if (loadPref(pref)) findAndSendColor();
 });
 
+
+var debouncePrevRun = 0;
+var debounceTimeout = null;
+
+/**
+ * Runs the given function with a maximum rate of 100ms.
+ *
+ * @param {function} fn
+ * @returns
+ */
+function withDebounce(fn) {
+	const timeout = 100;
+
+	return function () {
+		const curTime = Date.now();
+
+		if(debounceTimeout) {
+			// Clear any outstanding timeout.
+			clearTimeout(debounceTimeout);
+			debounceTimeout = null;
+		}
+
+		if(curTime - timeout > debouncePrevRun) {
+			// Been longer than the timeout? Just call the function now
+			debouncePrevRun = curTime;
+			fn();
+		} else {
+			// Too fast? Delay the function call
+			debounceTimeout = setTimeout(() => {
+				debouncePrevRun = Date.now();
+				debounceTimeout = null;
+				fn();
+			}, timeout - (curTime - debouncePrevRun));
+		}
+	}
+}
+
 /**
  * Sets up / Turns off dynamic update.
  * @param {boolean} dynamic Dynamic update.
  */
 function setDynamicUpdate(dynamic) {
+	const findAndSendColor_debounce = withDebounce(findAndSendColor);
+	const findAndSendColor_fix_debounce = withDebounce(findAndSendColor_fix);
+
 	if (dynamic) {
-		document.addEventListener("animationend", findAndSendColor_fix);
-		document.addEventListener("animationcancel", findAndSendColor_fix);
-		document.addEventListener("pageshow", findAndSendColor);
-		document.addEventListener("click", findAndSendColor);
-		document.addEventListener("resize", findAndSendColor);
-		document.addEventListener("scroll", findAndSendColor);
-		document.addEventListener("transitionend", findAndSendColor_fix);
-		document.addEventListener("transitioncancel", findAndSendColor_fix);
-		document.addEventListener("visibilitychange", findAndSendColor);
+		document.addEventListener("animationend", findAndSendColor_fix_debounce);
+		document.addEventListener("animationcancel", findAndSendColor_fix_debounce);
+		document.addEventListener("pageshow", findAndSendColor_debounce);
+		document.addEventListener("click", findAndSendColor_debounce);
+		document.addEventListener("resize", findAndSendColor_debounce);
+		document.addEventListener("scroll", findAndSendColor_debounce);
+		document.addEventListener("transitionend", findAndSendColor_fix_debounce);
+		document.addEventListener("transitioncancel", findAndSendColor_fix_debounce);
+		document.addEventListener("visibilitychange", findAndSendColor_debounce);
 	} else {
-		document.removeEventListener("animationend", findAndSendColor_fix);
-		document.removeEventListener("animationcancel", findAndSendColor_fix);
-		document.removeEventListener("click", findAndSendColor);
-		document.removeEventListener("pageshow", findAndSendColor);
-		document.removeEventListener("resize", findAndSendColor);
-		document.removeEventListener("scroll", findAndSendColor);
-		document.removeEventListener("transitionend", findAndSendColor_fix);
-		document.removeEventListener("transitioncancel", findAndSendColor_fix);
-		document.removeEventListener("visibilitychange", findAndSendColor);
+		document.removeEventListener("animationend", findAndSendColor_fix_debounce);
+		document.removeEventListener("animationcancel", findAndSendColor_fix_debounce);
+		document.removeEventListener("pageshow", findAndSendColor_debounce);
+		document.removeEventListener("click", findAndSendColor_debounce);
+		document.removeEventListener("resize", findAndSendColor_debounce);
+		document.removeEventListener("scroll", findAndSendColor_debounce);
+		document.removeEventListener("transitionend", findAndSendColor_fix_debounce);
+		document.removeEventListener("transitioncancel", findAndSendColor_fix_debounce);
+		document.removeEventListener("visibilitychange", findAndSendColor_debounce);
 	}
 }
 


### PR DESCRIPTION
### Description
Pretty much what it says in the title. The color is now recomputed and updated a maximum of once every 100ms. On my Macbook Pro M1 this translates to about 20-40 skipped recomputes depending on how fast you're scrolling.

### Reason
When scrolling through some webpages on Firefox I noticed some occasional hitching and frame-skips. Examining the Firefox profiling results it seemed to be related to the high amount of color computes and updates by the extension, which would update very often on my 120hz screen (probably due to the scroll eventListener).

This PR should help alleviate that, by restricting it to a certain frequency. I chose 100ms quite arbitrarily as it should be fast enough not to be super noticeable but long enough not to spam the CPU with requests. I think I made all the changes I should, but feel free to let me know if I missed something!